### PR TITLE
Add floating banner mode for non-blocking consent experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 
 # IDE
 .vscode/
+.npmrc

--- a/docs/consent-modes-and-gdpr.md
+++ b/docs/consent-modes-and-gdpr.md
@@ -1,0 +1,115 @@
+# Consent Modes and GDPR Compliance
+
+This document explains the different consent banner modes available in the consent manager and their implications for GDPR compliance.
+
+## Banner Modes
+
+### Blocking Mode (Default)
+
+```jsx
+<ConsentManager bannerMode="blocking" />
+```
+
+The banner appears as a full-screen overlay that prevents interaction with the underlying page until the user makes a consent choice.
+
+**Characteristics:**
+
+- Full-screen semi-transparent overlay
+- User cannot scroll or interact with the page
+- Forces an explicit consent decision before browsing
+- Most conservative approach for compliance
+
+### Floating Mode
+
+```jsx
+<ConsentManager bannerMode="floating" />
+```
+
+The banner appears as a floating element in the corner of the screen, allowing users to browse the site before making a consent decision.
+
+**Characteristics:**
+
+- Non-intrusive corner positioning (bottom-right on desktop, bottom bar on mobile)
+- User can scroll and interact with the page
+- No tracking occurs until explicit consent is given
+- Better user experience, still GDPR-compliant when configured correctly
+
+## GDPR Compliance Requirements
+
+Under GDPR, valid consent for non-essential cookies must be:
+
+1. **Freely given** - User must have a genuine choice without detriment
+2. **Specific** - Consent must be given for each specific purpose
+3. **Informed** - User must understand what they're consenting to
+4. **Unambiguous** - Requires a clear affirmative action
+
+### What This Means in Practice
+
+| Requirement  | How to Comply                                                    |
+| ------------ | ---------------------------------------------------------------- |
+| Freely given | Don't block essential site functionality based on consent choice |
+| Specific     | Use category-based consent (marketing, functional, advertising)  |
+| Informed     | Provide clear descriptions of what each category does            |
+| Unambiguous  | Require explicit button click - not just browsing/scrolling      |
+
+## The `implyConsentOnInteraction` Prop
+
+```jsx
+<ConsentManager implyConsentOnInteraction={true} />
+```
+
+This prop treats any click outside the consent banner as implicit acceptance of all cookies.
+
+### GDPR Compliance Warning
+
+**This prop is NOT GDPR-compliant for non-essential cookies.**
+
+The European Data Protection Board (EDPB) has explicitly stated that:
+
+> "Actions such as scrolling or swiping through a webpage or similar user activity will not under any circumstances satisfy the requirement of a clear and affirmative action."
+
+— EDPB Guidelines 05/2020 on consent under Regulation 2016/679
+
+### When `implyConsentOnInteraction` May Be Appropriate
+
+- Sites not subject to GDPR (non-EU users only)
+- Jurisdictions with less strict consent requirements
+- After explicit legal review and risk assessment
+- For truly essential/functional cookies only (though these don't require consent)
+
+### Recommended Configuration for GDPR Compliance
+
+```jsx
+<ConsentManager
+  bannerMode="floating" // Non-intrusive but visible
+  implyConsentOnInteraction={false} // Require explicit consent (default)
+  showRejectAll={true} // Give users a clear way to decline
+/>
+```
+
+## Pre-Consent Tracking Behaviour
+
+When using `bannerMode="floating"`, users can browse before consenting. During this pre-consent period:
+
+| Tracking Type                     | Behaviour               | GDPR Status |
+| --------------------------------- | ----------------------- | ----------- |
+| Analytics (Segment, GA, etc.)     | **Not loaded**          | Compliant   |
+| Advertising pixels                | **Not loaded**          | Compliant   |
+| Functional cookies                | **Not loaded**          | Compliant   |
+| Essential cookies (session, CSRF) | Allowed without consent | Compliant   |
+
+The consent manager follows a "no tracking until consent" approach, which is the safest default for GDPR compliance.
+
+## Summary
+
+| Configuration                                                | User Experience                       | GDPR Compliant | Recommended For              |
+| ------------------------------------------------------------ | ------------------------------------- | -------------- | ---------------------------- |
+| `bannerMode="blocking"`                                      | Must decide before browsing           | Yes            | Maximum compliance certainty |
+| `bannerMode="floating"`                                      | Can browse, explicit consent required | Yes            | Better UX with compliance    |
+| `bannerMode="floating"` + `implyConsentOnInteraction={true}` | Browsing implies consent              | **No**         | Non-EU sites only            |
+
+## Further Reading
+
+- [EDPB Guidelines on Consent](https://edpb.europa.eu/our-work-tools/our-documents/guidelines/guidelines-052020-consent-under-regulation-2016679_en)
+- [ICO Guidance on Cookies](https://ico.org.uk/for-organisations/guide-to-pecr/cookies-and-similar-technologies/)
+- [CNIL Cookie Guidelines](https://www.cnil.fr/en/cookies-and-other-tracking-devices-cnil-publishes-new-guidelines)

--- a/docs/consent-modes-and-gdpr.md
+++ b/docs/consent-modes-and-gdpr.md
@@ -108,8 +108,93 @@ The consent manager follows a "no tracking until consent" approach, which is the
 | `bannerMode="floating"`                                      | Can browse, explicit consent required | Yes            | Better UX with compliance    |
 | `bannerMode="floating"` + `implyConsentOnInteraction={true}` | Browsing implies consent              | **No**         | Non-EU sites only            |
 
+## Can You Track Before Consent? (Pre-Consent Analytics)
+
+A common question is whether you can collect any analytics data before users consent. The short answer: **it depends on the tool and method**.
+
+### The ePrivacy Directive Blocker
+
+Even if you claim "legitimate interest" under GDPR, the **ePrivacy Directive (Article 5(3))** requires consent for storing or accessing information on user devices. This means:
+
+- Cookies = consent required
+- LocalStorage = consent required
+- Device fingerprinting = consent required
+
+This applies regardless of your GDPR legal basis.
+
+### Path 1: Cookie-Free Anonymous Analytics (No Consent Required)
+
+Some privacy-focused analytics tools can run without consent because they:
+
+| Requirement              | Implementation                                 |
+| ------------------------ | ---------------------------------------------- |
+| No cookies               | Server-side session handling only              |
+| No persistent IDs        | Hash-based pseudonymization with rotating keys |
+| Immediate anonymization  | Data anonymized within 24 hours                |
+| No cross-device tracking | Each session treated independently             |
+| Aggregated data only     | No individual user profiles                    |
+
+**Tools that qualify:**
+
+- [Plausible Analytics](https://plausible.io/data-policy) - Open source, EU-hosted
+- [Fathom Analytics](https://usefathom.com/why-fathom-analytics/cookieless-analytics) - Cookieless by design
+- [Simple Analytics](https://www.simpleanalytics.com/) - No personal data collected
+
+These can run alongside your consent manager, providing basic metrics while users browse pre-consent.
+
+### Path 2: Legitimate Interest (Limited & Risky)
+
+Under GDPR Article 6(1)(f), you might claim legitimate interest for analytics, but only if:
+
+1. **No device storage used** (no cookies, localStorage, etc.)
+2. **Purpose limited to "reach measurement"** (page views, not user behaviour)
+3. **Legitimate Interests Assessment (LIA) conducted**
+4. **Data minimised and anonymised immediately**
+5. **No data transfers outside EU** (or adequate safeguards in place)
+
+**This does NOT apply to:**
+
+- Google Analytics (uses cookies, transfers to US)
+- Segment (uses persistent identifiers)
+- Any advertising or retargeting tracking
+- Cross-session user profiling
+
+### Why Segment Requires Consent
+
+This consent manager is built for Segment, which:
+
+- Uses cookies/identifiers for user tracking
+- Transfers data to US servers
+- Enables individual user analytics and profiling
+
+Therefore, **Segment-based tracking always requires explicit consent** under GDPR.
+
+### Hybrid Approach (Recommended)
+
+For the best balance of insights and compliance:
+
+```
+Pre-consent: Privacy-first analytics (Plausible, Fathom, etc.)
+             └─ Basic page views, referrers, device types
+             └─ No consent required
+             └─ Runs immediately on page load
+
+Post-consent: Full Segment tracking
+              └─ Detailed user analytics
+              └─ Advertising pixels
+              └─ Only after explicit consent
+```
+
+This gives you:
+
+- Immediate insights into all traffic
+- Full analytics for consenting users
+- Complete GDPR compliance
+
 ## Further Reading
 
 - [EDPB Guidelines on Consent](https://edpb.europa.eu/our-work-tools/our-documents/guidelines/guidelines-052020-consent-under-regulation-2016679_en)
 - [ICO Guidance on Cookies](https://ico.org.uk/for-organisations/guide-to-pecr/cookies-and-similar-technologies/)
 - [CNIL Cookie Guidelines](https://www.cnil.fr/en/cookies-and-other-tracking-devices-cnil-publishes-new-guidelines)
+- [Plausible: Legal Assessment for GDPR Compliance](https://plausible.io/blog/legal-assessment-gdpr-eprivacy)
+- [TermsFeed: Consent vs Legitimate Interest](https://www.termsfeed.com/blog/gdpr-user-consent-legitimate-interest/)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf commonjs esm standalone storybook-static types",
     "deploy-storybook": "storybook-to-ghpages",
     "standalone-hash": "shasum -b -a 256 standalone/consent-manager.js | xxd -r -p | base64",
-    "build-storybook": "yarn build-standalone && build-storybook && cp -r ./standalone ./storybook-static/standalone",
+    "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider yarn build-standalone && NODE_OPTIONS=--openssl-legacy-provider build-storybook && cp -r ./standalone ./storybook-static/standalone",
     "lint": "eslint 'src/**/*.{ts,tsx}'"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build-commonjs": "tsc --outDir commonjs --module CommonJS --inlineSourceMap",
     "build-esm": "tsc --module es2015 --outDir esm --inlineSourceMap",
     "build-standalone": "webpack",
-    "build": "concurrently --names 'commonjs,esm,standalone' 'yarn run build-commonjs' 'yarn run build-esm' 'yarn run build-standalone'",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider concurrently --names 'commonjs,esm,standalone' 'yarn run build-commonjs' 'yarn run build-esm' 'yarn run build-standalone'",
     "clean": "rm -rf commonjs esm standalone storybook-static types",
     "deploy-storybook": "storybook-to-ghpages",
     "standalone-hash": "shasum -b -a 256 standalone/consent-manager.js | xxd -r -p | base64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muchbetteradventures/consent-manager",
-  "version": "5.7.1-beta.0",
+  "version": "5.7.1-beta.1",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "jest src/__tests__",
     "prepublishOnly": "yarn run clean && yarn run build",
     "postpublish": "yarn build-storybook && yarn deploy-storybook -- --existing-output-dir=storybook-static",
-    "dev": "concurrently 'yarn build-standalone --watch' 'yarn start-storybook -s ./ -p 9009'",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider concurrently 'yarn build-standalone --watch' 'yarn start-storybook -s ./ -p 9009'",
     "build-commonjs": "tsc --outDir commonjs --module CommonJS --inlineSourceMap",
     "build-esm": "tsc --module es2015 --outDir esm --inlineSourceMap",
     "build-standalone": "webpack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muchbetteradventures/consent-manager",
-  "version": "5.7.0",
+  "version": "5.7.1-beta.0",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muchbetteradventures/consent-manager",
-  "version": "5.7.1-beta.1",
+  "version": "5.7.1-beta.2",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/src/consent-manager/banner.tsx
+++ b/src/consent-manager/banner.tsx
@@ -3,8 +3,9 @@ import styled from 'react-emotion'
 import { DefaultButton, TextButton } from './buttons'
 import { CloseBehavior, CloseBehaviorFunction } from './container'
 import fontStyles from './font-styles'
+import { BannerMode } from '../types'
 
-const Overlay = styled('div')`
+const BlockingOverlay = styled('div')`
   background: rgba(0, 0, 0, 0.2);
   position: fixed;
   top: 0;
@@ -19,29 +20,46 @@ const Overlay = styled('div')`
   }
 `
 
+const FloatingContainer = styled('div')`
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 1250;
+  max-width: 400px;
+  @media screen and (max-width: 600px) {
+    bottom: 0;
+    right: 0;
+    left: 0;
+    max-width: 100%;
+  }
+`
+
 const Title = styled('h4')`
   margin-top: 0;
   margin-bottom: 0.7em;
   text-transform: uppercase;
 `
 
-const Root = styled<{ backgroundColor: string; textColor: string }, 'div'>('div')`
+const Root = styled<{ backgroundColor: string; textColor: string; floating?: boolean }, 'div'>(
+  'div'
+)`
   ${fontStyles}
-  border-radius: 4px;
-  margin: 8px;
-  max-width: 500px;
+  border-radius: ${props => (props.floating ? '8px' : '4px')};
+  margin: ${props => (props.floating ? '0' : '8px')};
+  max-width: ${props => (props.floating ? '100%' : '500px')};
   padding: 16px;
   background: ${props => props.backgroundColor};
   color: ${props => props.textColor};
   font-size: 14px;
   line-height: 1.3;
   outline: none;
+  box-shadow: ${props => (props.floating ? '0 4px 12px rgba(0, 0, 0, 0.15)' : 'none')};
   &:focus {
     outline: none;
   }
   @media screen and (max-width: 600px) {
     margin: 0;
-    border-radius: 0;
+    border-radius: ${props => (props.floating ? '8px 8px 0 0' : '0')};
   }
 `
 
@@ -87,15 +105,19 @@ interface Props {
   backgroundColor: string
   textColor: string
   showRejectAll: boolean
+  bannerMode: BannerMode
 }
 
 export default class Banner extends PureComponent<Props> {
   static displayName = 'Banner'
 
   componentDidMount() {
-    const element = document.querySelector('[role="dialog"]')
-    if (element instanceof HTMLElement) {
-      element.focus()
+    // Only auto-focus in blocking mode to avoid interrupting browsing
+    if (this.props.bannerMode === 'blocking') {
+      const element = document.querySelector('[role="dialog"]')
+      if (element instanceof HTMLElement) {
+        element.focus()
+      }
     }
   }
 
@@ -107,17 +129,22 @@ export default class Banner extends PureComponent<Props> {
       content,
       backgroundColor,
       textColor,
-      showRejectAll
+      showRejectAll,
+      bannerMode
     } = this.props
 
+    const isFloating = bannerMode === 'floating'
+    const Container = isFloating ? FloatingContainer : BlockingOverlay
+
     return (
-      <Overlay>
+      <Container>
         <Root
           innerRef={innerRef}
           backgroundColor={backgroundColor}
           textColor={textColor}
+          floating={isFloating}
           role="dialog"
-          aria-modal="true"
+          aria-modal={!isFloating}
           tabIndex={-1}
         >
           <Content>
@@ -157,7 +184,7 @@ export default class Banner extends PureComponent<Props> {
             </DefaultButton>
           </Actions>
         </Root>
-      </Overlay>
+      </Container>
     )
   }
 }

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -7,7 +7,8 @@ import {
   Destination,
   CategoryPreferences,
   CustomCategories,
-  DefaultDestinationBehavior
+  DefaultDestinationBehavior,
+  BannerMode
 } from '../types'
 
 import { emitter as prefsEmitter } from '../consent-manager-builder/preferences'
@@ -48,6 +49,7 @@ interface ContainerProps {
   workspaceAddedNewDestinations?: boolean
   defaultDestinationBehavior?: DefaultDestinationBehavior
   showRejectAll: boolean
+  bannerMode: BannerMode
 }
 
 function normalizeDestinations(destinations: Destination[]) {
@@ -199,6 +201,7 @@ const Container: React.FC<ContainerProps> = props => {
           textColor={props.bannerTextColor}
           backgroundColor={props.bannerBackgroundColor}
           showRejectAll={props.showRejectAll}
+          bannerMode={props.bannerMode}
         />
       )}
 

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -25,7 +25,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     bannerBackgroundColor: '#fff',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     defaultDestinationBehavior: 'disable',
-    showRejectAll: false
+    showRejectAll: true
   }
 
   render() {

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -25,7 +25,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     bannerBackgroundColor: '#fff',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     defaultDestinationBehavior: 'disable',
-    showRejectAll: true
+    showRejectAll: true,
+    bannerMode: 'blocking' as const
   }
 
   render() {
@@ -45,7 +46,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       defaultDestinationBehavior,
       cdnHost,
       showRejectAll,
-      onError
+      onError,
+      bannerMode
     } = this.props
 
     return (
@@ -99,6 +101,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
               havePreferencesChanged={havePreferencesChanged}
               defaultDestinationBehavior={defaultDestinationBehavior}
               workspaceAddedNewDestinations={workspaceAddedNewDestinations}
+              bannerMode={bannerMode ?? ConsentManager.defaultProps.bannerMode}
             />
           )
         }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export type ConsentManagerInput = ConsentManagerProps & {
 
 export type DefaultDestinationBehavior = 'enable' | 'disable' | 'imply' | 'ask'
 
+export type BannerMode = 'blocking' | 'floating'
+
 interface StandaloneConsentManagerParams {
   React: unknown
   version?: string
@@ -94,4 +96,5 @@ export interface ConsentManagerProps {
   defaultDestinationBehavior?: DefaultDestinationBehavior
   cdnHost?: string
   showRejectAll: boolean
+  bannerMode?: BannerMode
 }

--- a/stories/8-floating-banner.stories.tsx
+++ b/stories/8-floating-banner.stories.tsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import cookies from 'js-cookie'
+import { Pane, Heading, Button, Paragraph } from 'evergreen-ui'
+import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
+import { storiesOf } from '@storybook/react'
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import SyntaxHighlighter from 'react-syntax-highlighter'
+import { Preferences } from '../src/types'
+import CookieView from './components/CookieView'
+
+const bannerContent = (
+  <span>
+    We use cookies (and other similar technologies) to collect data to improve your experience on
+    our site. By using our website, you're agreeing to the collection of data as described in our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </span>
+)
+const bannerSubContent = 'You can manage your preferences here!'
+const preferencesDialogTitle = 'Website Data Collection Preferences'
+const preferencesDialogContent = (
+  <div>
+    <p>
+      Segment uses data collected by cookies and JavaScript libraries to improve your browsing
+      experience, analyze site traffic, deliver personalized advertisements, and increase the
+      overall performance of our site.
+    </p>
+    <p>
+      By using our website, you're agreeing to our{' '}
+      <a
+        href="https://segment.com/docs/legal/website-data-collection-policy/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Website Data Collection Policy
+      </a>
+      .
+    </p>
+    <p>
+      The table below outlines how we use this data by category. To opt out of a category of data
+      collection, select "No" and save your preferences.
+    </p>
+  </div>
+)
+
+const FloatingBannerExample = () => {
+  const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
+
+  const cleanup = onPreferencesSaved(preferences => {
+    updatePrefs(preferences)
+  })
+
+  React.useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  })
+
+  return (
+    <Pane>
+      <ConsentManager
+        writeKey="tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0"
+        otherWriteKeys={['vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l']}
+        bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
+        preferencesDialogTitle={preferencesDialogTitle}
+        preferencesDialogContent={preferencesDialogContent}
+        bannerMode="floating"
+      />
+
+      <Pane marginX={100} marginTop={20}>
+        <Heading size={600} marginBottom={16}>
+          Floating Banner Mode Demo
+        </Heading>
+        <Paragraph marginBottom={16}>
+          This demonstrates the non-blocking floating banner mode. Users can interact with the page
+          while the consent banner is visible. The banner appears in the bottom-right corner on
+          desktop, and as a bottom bar on mobile.
+        </Paragraph>
+        <Paragraph marginBottom={16}>
+          <strong>Note:</strong> No tracking occurs until the user explicitly accepts or rejects
+          cookies. This is the GDPR-compliant default behaviour.
+        </Paragraph>
+
+        <Heading size={500} marginTop={24} marginBottom={16}>
+          Try scrolling and clicking around!
+        </Heading>
+
+        <Pane display="flex" gap={16}>
+          <iframe
+            src="https://source.unsplash.com/random/500x600"
+            width="480"
+            height="480"
+            frameBorder="0"
+          />
+
+          <iframe
+            src="https://source.unsplash.com/random/500x600"
+            width="398"
+            height="480"
+            frameBorder="0"
+          />
+        </Pane>
+
+        <Pane marginTop={24}>
+          <Heading size={400}>Current Preferences</Heading>
+          <SyntaxHighlighter language="json" style={docco}>
+            {JSON.stringify(prefs, null, 2)}
+          </SyntaxHighlighter>
+        </Pane>
+
+        <Pane marginTop={16}>
+          <Button marginRight={20} onClick={openConsentManager}>
+            Change Cookie Preferences
+          </Button>
+          <Button
+            onClick={() => {
+              cookies.remove('tracking-preferences')
+              window.location.reload()
+            }}
+          >
+            Clear Preferences
+          </Button>
+        </Pane>
+
+        {/* Extra content to demonstrate scrolling */}
+        <Pane marginTop={40}>
+          <Heading size={500} marginBottom={16}>
+            More Content Below
+          </Heading>
+          {[1, 2, 3, 4, 5].map(i => (
+            <Paragraph key={i} marginBottom={16}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+              exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+              dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            </Paragraph>
+          ))}
+        </Pane>
+      </Pane>
+      <CookieView />
+    </Pane>
+  )
+}
+
+storiesOf('React Component / Banner Mode', module)
+  .add('Floating Banner', () => <FloatingBannerExample />)
+  .add('Blocking Banner (Default)', () => (
+    <Pane>
+      <ConsentManager
+        writeKey="tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0"
+        bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
+        preferencesDialogTitle={preferencesDialogTitle}
+        preferencesDialogContent={preferencesDialogContent}
+        bannerMode="blocking"
+      />
+      <Pane marginX={100} marginTop={20}>
+        <Heading>Blocking Banner Mode (Default)</Heading>
+        <Paragraph>
+          This is the default blocking mode where users must interact with the banner before
+          accessing the site.
+        </Paragraph>
+      </Pane>
+    </Pane>
+  ))


### PR DESCRIPTION
## Summary

- **Add new `bannerMode` prop** supporting `"blocking"` (default) and `"floating"` modes for the consent banner
- **Add "Reject All" button** to the cookie modal for clearer user choice
- **Add documentation** explaining consent modes and GDPR compliance implications

The floating mode displays the consent banner as a non-intrusive element in the corner of the screen, allowing users to browse the site before making a consent decision. No tracking occurs until explicit consent is given, maintaining GDPR compliance while improving user experience.

## Test plan

- [ ] Verify blocking mode still works as before (full-screen overlay, auto-focus)
- [ ] Test floating mode on desktop (bottom-right positioning, shadow, rounded corners)
- [ ] Test floating mode on mobile (full-width bottom bar)
- [ ] Confirm no tracking scripts load until user explicitly consents
- [ ] Verify "Reject All" button functions correctly
- [ ] Check Storybook stories render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)